### PR TITLE
Fix BinaryOp value() default

### DIFF
--- a/Scientific calculator/BinaryOp.java
+++ b/Scientific calculator/BinaryOp.java
@@ -77,10 +77,10 @@ public class BinaryOp implements Function {
         }
     }
     
- // Implementation of value() method with no input
+    // Implementation of value() method with no input
     @Override
     public double value() {
-        return value(10); // Default input value of 10
+        throw new UnsupportedOperationException("Input expected.");
     }
     /**
      * Returns the binary operator.


### PR DESCRIPTION
## Summary
- fix incorrect default in `BinaryOp.value()` to throw exception instead of returning value for 10

## Testing
- `javac *.java`